### PR TITLE
Fix extra height in large screen

### DIFF
--- a/src/styles/characterController.css
+++ b/src/styles/characterController.css
@@ -61,9 +61,17 @@ width: 116%;
 }
 
 .separator{
-  height: 106vh;
+  height: auto;
+  min-height: 667px;
   border: 0.5px solid;
   color: black;
+}
+
+
+@media screen and (min-height : 760px) {
+  .separator{
+    height: 100vh;
+  }
 }
 
 #question {


### PR DESCRIPTION
according to height issue #34 I did the following:
- add `height: auto` to separator class
- in the large screen height Seperator height became 100vh and if did not do this the side bar and Seperator height won't change